### PR TITLE
Add Grow Invest landing page with responsive views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import AdminStatsPage from './pages/AdminStatsPage';
 import AdminPanel from './pages/AdminPanel';
 // import SocialMediaPage from './pages/SocialMediapage';
 import SocialMediaPage from './pages/SocialMedia';
+import GrowInvestPage from './pages/GrowInvestPage';
 
 function ScrollToSectionOnRouteChange() {
   const location = useLocation();
@@ -75,6 +76,7 @@ function App() {
       <AnimatePresence mode="wait">
         <Routes location={location} key={location.pathname}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/grow-invest" element={<GrowInvestPage />} />
           <Route path="/services" element={<ServicesPage />} />
           <Route path="/portfolio" element={<PortfolioPage />} />
           <Route path="/portfolio/brochure" element={<BrochurePage />} />

--- a/src/components/growInvest/GrowInvestDesktop.tsx
+++ b/src/components/growInvest/GrowInvestDesktop.tsx
@@ -1,0 +1,263 @@
+import React from 'react';
+import { ArrowRight, PlayCircle } from 'lucide-react';
+import {
+  heroStats,
+  features,
+  services,
+  processSteps,
+  advantages,
+  marketHighlights,
+  testimonials,
+  faqs,
+  partnershipHighlights,
+  closingCTA
+} from '../../data/growInvest';
+
+const GrowInvestDesktop: React.FC = () => {
+  return (
+    <div className="relative overflow-hidden bg-slate-950 text-slate-100">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,#1e293b,transparent_60%)]" aria-hidden />
+      <div className="relative mx-auto max-w-7xl px-12">
+        {/* Hero */}
+        <section className="grid min-h-[80vh] grid-cols-[1.1fr_0.9fr] gap-16 py-24">
+          <div className="flex flex-col justify-center space-y-10">
+            <span className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm uppercase tracking-[0.3em] text-slate-200">
+              Grow Invest
+            </span>
+            <div className="space-y-6">
+              <h1 className="text-6xl font-semibold leading-tight text-white">
+                Intelligent wealth management for ambitious leaders
+              </h1>
+              <p className="max-w-2xl text-lg text-slate-300">
+                Grow Invest partners with founders, executives, and families to design resilient portfolios
+                that outperform the market while staying aligned with your values.
+              </p>
+            </div>
+            <div className="flex items-center gap-6">
+              <button className="group inline-flex items-center gap-3 rounded-full bg-orange-500 px-7 py-3 text-lg font-medium text-white shadow-lg shadow-orange-500/30 transition hover:-translate-y-0.5 hover:bg-orange-400">
+                Start a conversation
+                <ArrowRight className="h-5 w-5 transition group-hover:translate-x-1" />
+              </button>
+              <button className="inline-flex items-center gap-3 rounded-full border border-white/10 px-6 py-3 text-lg font-medium text-white/80 transition hover:border-white/30 hover:text-white">
+                <PlayCircle className="h-6 w-6" />
+                Meet our team
+              </button>
+            </div>
+            <div className="grid grid-cols-3 gap-6 pt-6">
+              {heroStats.map((stat) => (
+                <div key={stat.label} className="rounded-2xl border border-white/5 bg-white/5 p-6 backdrop-blur">
+                  <p className="text-sm uppercase tracking-[0.35em] text-orange-300">{stat.label}</p>
+                  <p className="mt-3 text-3xl font-semibold text-white">{stat.value}</p>
+                  <p className="mt-2 text-sm text-slate-300">{stat.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="relative flex items-center">
+            <div className="relative w-full rounded-[3rem] border border-white/10 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-950 p-12 shadow-2xl">
+              <div className="absolute inset-x-8 -top-8 h-40 rounded-3xl bg-gradient-to-r from-orange-500/40 to-pink-500/40 blur-3xl" aria-hidden />
+              <div className="relative space-y-10">
+                <div>
+                  <p className="text-sm uppercase tracking-[0.4em] text-orange-200">Strategy snapshot</p>
+                  <p className="mt-3 text-4xl font-semibold text-white">Active + Alternative</p>
+                </div>
+                <div className="grid grid-cols-2 gap-5">
+                  {marketHighlights.map((highlight) => (
+                    <div key={highlight.title} className="flex flex-col gap-3 rounded-2xl border border-white/5 bg-white/5 p-5">
+                      <highlight.icon className="h-6 w-6 text-orange-300" />
+                      <p className="text-base font-medium text-white">{highlight.title}</p>
+                      <p className="text-sm text-slate-300">{highlight.description}</p>
+                    </div>
+                  ))}
+                </div>
+                <div className="rounded-2xl border border-orange-500/40 bg-gradient-to-r from-orange-500/20 to-rose-500/20 p-6">
+                  <p className="text-sm uppercase tracking-[0.4em] text-orange-200">In Focus</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">Q3 Market Outlook</p>
+                  <p className="mt-3 text-sm text-slate-200">
+                    Diversifying fixed income with sustainable infrastructure debt and capturing AI-led growth in public equities.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Features */}
+        <section className="space-y-12 py-20">
+          <div className="max-w-4xl space-y-4">
+            <p className="text-sm uppercase tracking-[0.4em] text-orange-200">Why Grow Invest</p>
+            <h2 className="text-4xl font-semibold text-white">Designed for growth, grounded in discipline</h2>
+            <p className="text-lg text-slate-300">
+              From high-growth entrepreneurs to multigenerational families, we provide clarity, conviction, and
+              measurable outcomes.
+            </p>
+          </div>
+          <div className="grid grid-cols-3 gap-8">
+            {features.map((feature) => (
+              <div key={feature.title} className="rounded-3xl border border-white/5 bg-white/5 p-8 transition hover:-translate-y-1 hover:border-orange-400/40">
+                <feature.icon className="h-10 w-10 text-orange-300" />
+                <h3 className="mt-6 text-2xl font-semibold text-white">{feature.title}</h3>
+                <p className="mt-3 text-base text-slate-300">{feature.description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Services */}
+        <section className="rounded-[3rem] border border-white/10 bg-gradient-to-br from-slate-900/80 via-slate-900 to-slate-950 p-16 shadow-[0_40px_120px_-40px_rgba(15,23,42,0.7)]">
+          <div className="flex items-end justify-between">
+            <div className="max-w-3xl space-y-4">
+              <p className="text-sm uppercase tracking-[0.4em] text-orange-200">What we do</p>
+              <h2 className="text-4xl font-semibold text-white">Holistic advisory for every chapter of your wealth journey</h2>
+            </div>
+            <div className="text-right text-sm text-slate-300">
+              <p>Dedicated advisors • Institutional research • Transparent reporting</p>
+            </div>
+          </div>
+          <div className="mt-14 grid grid-cols-3 gap-10">
+            {services.map((service) => (
+              <div key={service.title} className="flex flex-col gap-6 rounded-3xl border border-white/5 bg-white/[0.04] p-8">
+                <service.icon className="h-10 w-10 text-orange-300" />
+                <div>
+                  <h3 className="text-2xl font-semibold text-white">{service.title}</h3>
+                  <p className="mt-2 text-sm text-slate-300">{service.description}</p>
+                </div>
+                <ul className="space-y-3 text-sm text-slate-200">
+                  {service.points.map((point) => (
+                    <li key={point} className="flex items-start gap-3">
+                      <span className="mt-1 h-2 w-2 rounded-full bg-orange-400" />
+                      <span>{point}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Process */}
+        <section className="grid grid-cols-[0.8fr_1.2fr] gap-12 py-24">
+          <div className="space-y-6">
+            <p className="text-sm uppercase tracking-[0.4em] text-orange-200">Our process</p>
+            <h2 className="text-4xl font-semibold text-white">Collaborative at every milestone</h2>
+            <p className="text-lg text-slate-300">
+              Stay informed and empowered with structured reviews, real-time dashboards, and swift access to
+              specialists.
+            </p>
+            <div className="space-y-5">
+              {advantages.map((advantage) => (
+                <div key={advantage.title} className="rounded-2xl border border-white/5 bg-white/5 p-5">
+                  <h3 className="text-xl font-semibold text-white">{advantage.title}</h3>
+                  <p className="mt-2 text-sm text-slate-300">{advantage.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-6">
+            {processSteps.map((step, index) => (
+              <div key={step.title} className="group relative overflow-hidden rounded-3xl border border-white/5 bg-white/5 p-6">
+                <div className="absolute inset-0 bg-gradient-to-br from-orange-500/0 via-orange-500/0 to-orange-500/20 opacity-0 transition group-hover:opacity-100" aria-hidden />
+                <div className="relative">
+                  <div className="flex items-center justify-between text-sm text-orange-200">
+                    <span>Phase {index + 1}</span>
+                    <step.icon className="h-6 w-6" />
+                  </div>
+                  <h3 className="mt-4 text-2xl font-semibold text-white">{step.title}</h3>
+                  <p className="mt-3 text-sm text-slate-300">{step.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Testimonials */}
+        <section className="grid grid-cols-[1fr_1fr] gap-12 rounded-[3rem] border border-white/10 bg-white/[0.04] p-16">
+          <div className="space-y-4">
+            <p className="text-sm uppercase tracking-[0.4em] text-orange-200">Client voices</p>
+            <h2 className="text-4xl font-semibold text-white">Trusted partners across industries</h2>
+            <p className="text-lg text-slate-300">
+              From technology scale-ups to legacy enterprises, our clients count on us for responsive, proactive
+              support.
+            </p>
+          </div>
+          <div className="grid gap-6">
+            {testimonials.map((testimonial) => (
+              <figure key={testimonial.author} className="rounded-3xl border border-white/5 bg-slate-900/80 p-8">
+                <blockquote className="text-lg text-slate-200">“{testimonial.quote}”</blockquote>
+                <figcaption className="mt-6 text-sm text-slate-400">
+                  <span className="font-medium text-white">{testimonial.author}</span> · {testimonial.role}
+                </figcaption>
+              </figure>
+            ))}
+          </div>
+        </section>
+
+        {/* Partnership */}
+        <section className="py-24">
+          <div className="flex items-start gap-20">
+            <div className="w-1/3 space-y-4">
+              <p className="text-sm uppercase tracking-[0.4em] text-orange-200">Beyond advisory</p>
+              <h2 className="text-4xl font-semibold text-white">Partnerships built for longevity</h2>
+              <p className="text-lg text-slate-300">
+                We integrate with your family office, finance team, and legal partners to deliver cohesive financial
+                leadership.
+              </p>
+            </div>
+            <div className="flex-1 grid grid-cols-3 gap-8">
+              {partnershipHighlights.map((highlight) => (
+                <div key={highlight.title} className="rounded-3xl border border-white/5 bg-white/5 p-6">
+                  <highlight.icon className="h-8 w-8 text-orange-300" />
+                  <h3 className="mt-5 text-xl font-semibold text-white">{highlight.title}</h3>
+                  <p className="mt-3 text-sm text-slate-300">{highlight.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="rounded-[3rem] border border-white/10 bg-slate-900/70 p-16">
+          <div className="grid grid-cols-[0.8fr_1.2fr] gap-12">
+            <div className="space-y-4">
+              <p className="text-sm uppercase tracking-[0.4em] text-orange-200">FAQs</p>
+              <h2 className="text-4xl font-semibold text-white">We make complex decisions simple</h2>
+              <p className="text-lg text-slate-300">
+                Transparent communication ensures you know exactly how your capital is performing and why strategic
+                shifts occur.
+              </p>
+            </div>
+            <div className="space-y-4">
+              {faqs.map((faq) => (
+                <div key={faq.question} className="rounded-2xl border border-white/5 bg-white/5 p-6">
+                  <h3 className="text-xl font-semibold text-white">{faq.question}</h3>
+                  <p className="mt-3 text-sm text-slate-300">{faq.answer}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="relative my-24 rounded-[3rem] border border-orange-500/40 bg-gradient-to-br from-orange-500/20 via-rose-500/10 to-purple-500/20 p-16 text-white">
+          <div className="absolute inset-0 -z-10 blur-3xl" aria-hidden />
+          <div className="flex items-center justify-between">
+            <div className="max-w-2xl space-y-4">
+              <h2 className="text-4xl font-semibold">{closingCTA.heading}</h2>
+              <p className="text-lg text-orange-100/80">{closingCTA.subheading}</p>
+            </div>
+            <div className="flex gap-4">
+              <button className="rounded-full bg-white px-7 py-3 text-lg font-semibold text-slate-900 transition hover:-translate-y-0.5">
+                {closingCTA.primaryLabel}
+              </button>
+              <button className="rounded-full border border-white/60 px-7 py-3 text-lg font-semibold text-white transition hover:-translate-y-0.5 hover:border-white">
+                {closingCTA.secondaryLabel}
+              </button>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default GrowInvestDesktop;

--- a/src/components/growInvest/GrowInvestMobile.tsx
+++ b/src/components/growInvest/GrowInvestMobile.tsx
@@ -1,0 +1,235 @@
+import React from 'react';
+import { ArrowRight, PlayCircle } from 'lucide-react';
+import {
+  heroStats,
+  features,
+  services,
+  processSteps,
+  advantages,
+  marketHighlights,
+  testimonials,
+  faqs,
+  partnershipHighlights,
+  closingCTA
+} from '../../data/growInvest';
+
+const GrowInvestMobile: React.FC = () => {
+  return (
+    <div className="space-y-16 bg-slate-950 px-6 pb-20 pt-16 text-slate-100">
+      {/* Hero */}
+      <section className="space-y-8">
+        <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-xs uppercase tracking-[0.3em] text-slate-200">
+          Grow Invest
+        </span>
+        <div className="space-y-4">
+          <h1 className="text-4xl font-semibold leading-tight text-white">
+            Intelligent wealth management for ambitious leaders
+          </h1>
+          <p className="text-base text-slate-300">
+            Grow Invest partners with founders, executives, and families to design resilient portfolios aligned with your ambitions.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3">
+          <button className="group inline-flex items-center justify-center gap-3 rounded-full bg-orange-500 px-6 py-3 text-base font-semibold text-white shadow-lg shadow-orange-500/30 transition hover:-translate-y-0.5 hover:bg-orange-400">
+            Start a conversation
+            <ArrowRight className="h-5 w-5 transition group-hover:translate-x-1" />
+          </button>
+          <button className="inline-flex items-center justify-center gap-3 rounded-full border border-white/10 px-6 py-3 text-base font-semibold text-white/80 transition hover:border-white/30 hover:text-white">
+            <PlayCircle className="h-6 w-6" />
+            Meet our team
+          </button>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {heroStats.map((stat) => (
+            <div key={stat.label} className="rounded-2xl border border-white/5 bg-white/5 p-5 text-center">
+              <p className="text-xs uppercase tracking-[0.4em] text-orange-300">{stat.label}</p>
+              <p className="mt-2 text-2xl font-semibold text-white">{stat.value}</p>
+              <p className="mt-2 text-xs text-slate-300">{stat.description}</p>
+            </div>
+          ))}
+        </div>
+        <div className="space-y-5 rounded-[2rem] border border-white/10 bg-gradient-to-br from-slate-900/80 via-slate-900 to-slate-950 p-6">
+          <div>
+            <p className="text-xs uppercase tracking-[0.4em] text-orange-200">Strategy snapshot</p>
+            <p className="mt-2 text-2xl font-semibold text-white">Active + Alternative</p>
+          </div>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {marketHighlights.map((highlight) => (
+              <div key={highlight.title} className="flex flex-col gap-2 rounded-2xl border border-white/5 bg-white/5 p-4">
+                <highlight.icon className="h-6 w-6 text-orange-300" />
+                <p className="text-base font-medium text-white">{highlight.title}</p>
+                <p className="text-sm text-slate-300">{highlight.description}</p>
+              </div>
+            ))}
+          </div>
+          <div className="rounded-2xl border border-orange-500/40 bg-gradient-to-r from-orange-500/20 to-rose-500/20 p-4">
+            <p className="text-xs uppercase tracking-[0.4em] text-orange-200">In Focus</p>
+            <p className="mt-2 text-xl font-semibold text-white">Q3 Market Outlook</p>
+            <p className="mt-2 text-sm text-slate-200">
+              Diversifying fixed income with sustainable infrastructure debt and capturing AI-led growth in public equities.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Features */}
+      <section className="space-y-8">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-orange-200">Why Grow Invest</p>
+          <h2 className="text-3xl font-semibold text-white">Designed for growth, grounded in discipline</h2>
+          <p className="text-base text-slate-300">
+            We provide clarity, conviction, and measurable outcomes for every stage of your wealth journey.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+          {features.map((feature) => (
+            <div key={feature.title} className="rounded-3xl border border-white/5 bg-white/5 p-6">
+              <feature.icon className="h-8 w-8 text-orange-300" />
+              <h3 className="mt-4 text-xl font-semibold text-white">{feature.title}</h3>
+              <p className="mt-2 text-sm text-slate-300">{feature.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Services */}
+      <section className="space-y-8 rounded-[2.5rem] border border-white/10 bg-gradient-to-b from-slate-900/80 via-slate-900 to-slate-950 p-8">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-orange-200">What we do</p>
+          <h2 className="text-3xl font-semibold text-white">Holistic advisory for your ambitions</h2>
+          <p className="text-base text-slate-300">
+            Dedicated advisors, institutional research, and transparent reporting at your fingertips.
+          </p>
+        </div>
+        <div className="space-y-6">
+          {services.map((service) => (
+            <div key={service.title} className="flex flex-col gap-4 rounded-3xl border border-white/5 bg-white/5 p-6">
+              <service.icon className="h-9 w-9 text-orange-300" />
+              <div>
+                <h3 className="text-2xl font-semibold text-white">{service.title}</h3>
+                <p className="mt-2 text-sm text-slate-300">{service.description}</p>
+              </div>
+              <ul className="space-y-3 text-sm text-slate-200">
+                {service.points.map((point) => (
+                  <li key={point} className="flex items-start gap-3">
+                    <span className="mt-1 h-2 w-2 rounded-full bg-orange-400" />
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Process */}
+      <section className="space-y-8">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-orange-200">Our process</p>
+          <h2 className="text-3xl font-semibold text-white">Collaborative at every milestone</h2>
+          <p className="text-base text-slate-300">
+            Stay informed and empowered with structured reviews, real-time dashboards, and swift access to specialists.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {processSteps.map((step, index) => (
+            <div key={step.title} className="group rounded-3xl border border-white/5 bg-white/5 p-6">
+              <div className="flex items-center justify-between text-xs text-orange-200">
+                <span>Phase {index + 1}</span>
+                <step.icon className="h-5 w-5" />
+              </div>
+              <h3 className="mt-4 text-xl font-semibold text-white">{step.title}</h3>
+              <p className="mt-2 text-sm text-slate-300">{step.description}</p>
+            </div>
+          ))}
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {advantages.map((advantage) => (
+            <div key={advantage.title} className="rounded-3xl border border-white/5 bg-white/5 p-5">
+              <h3 className="text-lg font-semibold text-white">{advantage.title}</h3>
+              <p className="mt-2 text-sm text-slate-300">{advantage.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Testimonials */}
+      <section className="space-y-6 rounded-[2.5rem] border border-white/10 bg-white/[0.04] p-8">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-orange-200">Client voices</p>
+          <h2 className="text-3xl font-semibold text-white">Trusted partners across industries</h2>
+          <p className="text-base text-slate-300">
+            From technology scale-ups to legacy enterprises, our clients count on us for responsive, proactive support.
+          </p>
+        </div>
+        <div className="space-y-4">
+          {testimonials.map((testimonial) => (
+            <figure key={testimonial.author} className="rounded-3xl border border-white/5 bg-slate-900/80 p-6">
+              <blockquote className="text-base text-slate-200">“{testimonial.quote}”</blockquote>
+              <figcaption className="mt-4 text-xs text-slate-400">
+                <span className="font-medium text-white">{testimonial.author}</span> · {testimonial.role}
+              </figcaption>
+            </figure>
+          ))}
+        </div>
+      </section>
+
+      {/* Partnerships */}
+      <section className="space-y-6">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-orange-200">Beyond advisory</p>
+          <h2 className="text-3xl font-semibold text-white">Partnerships built for longevity</h2>
+          <p className="text-base text-slate-300">
+            We integrate with your family office, finance team, and legal partners to deliver cohesive financial leadership.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {partnershipHighlights.map((highlight) => (
+            <div key={highlight.title} className="rounded-3xl border border-white/5 bg-white/5 p-5">
+              <highlight.icon className="h-7 w-7 text-orange-300" />
+              <h3 className="mt-4 text-lg font-semibold text-white">{highlight.title}</h3>
+              <p className="mt-2 text-sm text-slate-300">{highlight.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="space-y-5 rounded-[2.5rem] border border-white/10 bg-slate-900/70 p-8">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-orange-200">FAQs</p>
+          <h2 className="text-3xl font-semibold text-white">We make complex decisions simple</h2>
+          <p className="text-base text-slate-300">
+            Transparent communication ensures you know exactly how your capital is performing and why strategic shifts occur.
+          </p>
+        </div>
+        <div className="space-y-4">
+          {faqs.map((faq) => (
+            <div key={faq.question} className="rounded-3xl border border-white/5 bg-white/5 p-6">
+              <h3 className="text-lg font-semibold text-white">{faq.question}</h3>
+              <p className="mt-2 text-sm text-slate-300">{faq.answer}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="space-y-4 rounded-[2.5rem] border border-orange-500/40 bg-gradient-to-br from-orange-500/20 via-rose-500/10 to-purple-500/20 p-8 text-white">
+        <div className="space-y-3">
+          <h2 className="text-3xl font-semibold">{closingCTA.heading}</h2>
+          <p className="text-base text-orange-100/80">{closingCTA.subheading}</p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <button className="flex-1 rounded-full bg-white px-6 py-3 text-base font-semibold text-slate-900 transition hover:-translate-y-0.5">
+            {closingCTA.primaryLabel}
+          </button>
+          <button className="flex-1 rounded-full border border-white/60 px-6 py-3 text-base font-semibold text-white transition hover:-translate-y-0.5 hover:border-white">
+            {closingCTA.secondaryLabel}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default GrowInvestMobile;

--- a/src/data/growInvest.ts
+++ b/src/data/growInvest.ts
@@ -1,0 +1,220 @@
+import { type LucideIcon, BarChart3, Leaf, ShieldCheck, Users2, Coins, PieChart, Wallet2, Target, Trophy, LineChart, Briefcase, Sparkles, CheckCircle2, Building2, Globe2 } from 'lucide-react';
+
+export interface GrowInvestStat {
+  label: string;
+  value: string;
+  description: string;
+}
+
+export interface GrowInvestFeature {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+export interface GrowInvestService {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+  points: string[];
+}
+
+export interface GrowInvestProcessStep {
+  title: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+export interface GrowInvestTestimonial {
+  quote: string;
+  author: string;
+  role: string;
+}
+
+export interface GrowInvestAdvantage {
+  title: string;
+  description: string;
+}
+
+export interface GrowInvestFAQ {
+  question: string;
+  answer: string;
+}
+
+export const heroStats: GrowInvestStat[] = [
+  {
+    label: 'Client Retention',
+    value: '97%',
+    description: 'Long-term partnerships built on trust and results'
+  },
+  {
+    label: 'Assets Managed',
+    value: '$2.1B',
+    description: 'Diverse portfolios spanning global markets'
+  },
+  {
+    label: 'Average ROI',
+    value: '14%',
+    description: 'Year-over-year growth across client portfolios'
+  }
+];
+
+export const features: GrowInvestFeature[] = [
+  {
+    title: 'Tailored Growth Strategies',
+    description: 'Dynamic portfolios designed around your goals, risk tolerance, and time horizon.',
+    icon: LineChart
+  },
+  {
+    title: 'Sustainable Investing',
+    description: 'ESG-focused opportunities that align wealth creation with meaningful impact.',
+    icon: Leaf
+  },
+  {
+    title: 'Expert Advisory Team',
+    description: 'Seasoned analysts and advisors monitoring market shifts in real time.',
+    icon: Users2
+  }
+];
+
+export const services: GrowInvestService[] = [
+  {
+    title: 'Wealth Management',
+    description: 'Comprehensive asset management with quarterly strategy reviews and transparent performance reporting.',
+    icon: Wallet2,
+    points: [
+      'Portfolio diversification across asset classes',
+      'Active risk monitoring and rebalancing',
+      'Tax-efficient investment planning'
+    ]
+  },
+  {
+    title: 'Retirement Planning',
+    description: 'Future-proof your lifestyle with strategies that balance safety, liquidity, and growth.',
+    icon: ShieldCheck,
+    points: [
+      'Cash flow modelling and milestone planning',
+      'Income strategies for pre and post retirement',
+      'Protection against inflation and market swings'
+    ]
+  },
+  {
+    title: 'Corporate Advisory',
+    description: 'Guidance for founders and CFOs managing treasury operations, fundraising, and expansion.',
+    icon: Briefcase,
+    points: [
+      'Capital allocation and growth planning',
+      'ESOP and incentive structuring',
+      'Cross-border investment opportunities'
+    ]
+  }
+];
+
+export const processSteps: GrowInvestProcessStep[] = [
+  {
+    title: 'Discovery & Insight',
+    description: 'We start with deep discovery to understand your aspirations, obligations, and current financial landscape.',
+    icon: Sparkles
+  },
+  {
+    title: 'Strategy Blueprint',
+    description: 'Our advisory team crafts a bespoke investment roadmap supported by data-led market research.',
+    icon: Target
+  },
+  {
+    title: 'Execution & Optimization',
+    description: 'Portfolios are actively managed with scenario planning, hedging, and tactical adjustments.',
+    icon: BarChart3
+  },
+  {
+    title: 'Review & Elevate',
+    description: 'Quarterly performance sessions to recalibrate goals and capture new opportunities.',
+    icon: Trophy
+  }
+];
+
+export const advantages: GrowInvestAdvantage[] = [
+  {
+    title: 'Global Perspective',
+    description: 'Access to emerging and developed markets through our global research network.'
+  },
+  {
+    title: 'Quant-Driven Decisions',
+    description: 'Advanced analytics and predictive modelling inform every investment recommendation.'
+  },
+  {
+    title: 'Dedicated Support',
+    description: 'A single point of contact backed by a multidisciplinary team for seamless communication.'
+  }
+];
+
+export const marketHighlights: GrowInvestFeature[] = [
+  {
+    title: 'Real-time Market Monitoring',
+    description: '24/7 portfolio oversight with proactive alerts and scenario planning.',
+    icon: PieChart
+  },
+  {
+    title: 'Alternative Investments',
+    description: 'Access private equity, venture debt, and structured products vetted by our committee.',
+    icon: Coins
+  },
+  {
+    title: 'Institutional Partnerships',
+    description: 'Collaborations with leading custodians and research houses for robust execution.',
+    icon: Building2
+  }
+];
+
+export const testimonials: GrowInvestTestimonial[] = [
+  {
+    quote: 'Grow Invest transformed our treasury approach. Their proactive insights helped us capture growth opportunities even in volatile markets.',
+    author: 'Amelia Chen',
+    role: 'CFO, Lumen Labs'
+  },
+  {
+    quote: 'Their advisory team blends empathy with precision. We finally have clarity and confidence in our long-term wealth plan.',
+    author: 'Rahul Desai',
+    role: 'Founder, Desai Ventures'
+  }
+];
+
+export const faqs: GrowInvestFAQ[] = [
+  {
+    question: 'How do you tailor portfolios for different risk profiles?',
+    answer: 'We combine qualitative conversations with quantitative risk assessments to build a portfolio mix that evolves with your life stage and market conditions.'
+  },
+  {
+    question: 'What is the minimum investment to work with Grow Invest?',
+    answer: 'Individual wealth mandates begin at $500K AUM, while corporate advisory engagements are scoped based on treasury size and strategic objectives.'
+  },
+  {
+    question: 'How often will I hear from my advisory team?',
+    answer: 'You receive monthly performance dashboards and quarterly strategic reviews, with your advisor available on-demand for timely updates.'
+  }
+];
+
+export const partnershipHighlights: GrowInvestFeature[] = [
+  {
+    title: 'Integrated Reporting',
+    description: 'Consolidated dashboards across brokerage accounts, private investments, and real estate holdings.',
+    icon: Globe2
+  },
+  {
+    title: 'Compliance & Governance',
+    description: 'Robust frameworks that keep your portfolio aligned with regulatory requirements.',
+    icon: ShieldCheck
+  },
+  {
+    title: 'Impact Measurement',
+    description: 'Track the social and environmental performance of every ESG investment.',
+    icon: CheckCircle2
+  }
+];
+
+export const closingCTA = {
+  heading: 'Let’s shape your next decade of growth',
+  subheading: 'Partner with a team that treats your ambitions like our own. Schedule a discovery session with Grow Invest today.',
+  primaryLabel: 'Book a Consultation',
+  secondaryLabel: 'Download Firm Overview'
+};

--- a/src/pages/GrowInvestPage.tsx
+++ b/src/pages/GrowInvestPage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import GrowInvestDesktop from '../components/growInvest/GrowInvestDesktop';
+import GrowInvestMobile from '../components/growInvest/GrowInvestMobile';
+
+const GrowInvestPage: React.FC = () => {
+  return (
+    <main className="min-h-screen bg-slate-950 font-inter text-slate-100">
+      <div className="lg:hidden">
+        <GrowInvestMobile />
+      </div>
+      <div className="hidden lg:block">
+        <GrowInvestDesktop />
+      </div>
+    </main>
+  );
+};
+
+export default GrowInvestPage;


### PR DESCRIPTION
## Summary
- add Grow Invest data definitions to drive the new experience
- build dedicated desktop and combined mobile/tablet components for the Grow Invest site
- expose a Grow Invest page and route within the app shell

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7171ca208327a8ea28385336de17